### PR TITLE
Added img element

### DIFF
--- a/src/main/kotlin/io/kweb/dom/element/creation/tags/other.kt
+++ b/src/main/kotlin/io/kweb/dom/element/creation/tags/other.kt
@@ -75,3 +75,11 @@ fun ElementCreator<Element>.nav(attributes: Map<String, Any> = attr) = NavElemen
 
 open class SectionElement(parent: Element) : Element(parent)
 fun ElementCreator<Element>.section(attributes: Map<String, Any> = attr) = SectionElement(element("section", attributes))
+
+open class ImageElement(parent: Element) : Element(parent)
+/**
+ * @param src The image source. The source must be from an external server since Kweb doesn't handle internal routing yet
+ * @param attributes Extra attributes you want to add
+ */
+fun ElementCreator<Element>.img(src: String? = null, attributes: Map<String, Any> = attr) =
+        ImageElement(element("img", attributes.set("src", src)))


### PR DESCRIPTION
Added an `img` element so you don't have to write `element("img", attributes = mapOf("src" to path))`

Made a note in the documentation that you can't link images that are internal to Kweb since internal routing isn't setup yet.